### PR TITLE
Remove need for C++20 use by switching to 'count(key) > 0'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,3 @@ RoxygenNote: 7.3.2
 URL: https://github.com/svensglinz/hashmapR
 Suggests:
     testthat (>= 3.0.0)
-SystemRequirements: C++20

--- a/src/hashmap.cpp
+++ b/src/hashmap.cpp
@@ -227,7 +227,7 @@ class Hashmap {
     }   
 
     SEXP contains(SEXP key) const {
-        return Rf_ScalarLogical(this->map_.contains(key));
+        return Rf_ScalarLogical(this->map_.count(key) > 0);
     }
 
     SEXP contains_range(SEXP keys) const {
@@ -236,7 +236,7 @@ class Hashmap {
 
         for (std::size_t i = 0; i < len; i++) {
             SEXP k = VECTOR_ELT(keys, i);
-            LOGICAL(list)[i] = this->map_.contains(k);
+            LOGICAL(list)[i] = this->map_.count(k) > 0;
         }
         UNPROTECT(1);
         return list;


### PR DESCRIPTION
Closes #1 

As discussed, we can test for presence of a key via `count(key) > 0` which, while not as elegant as the C++20 predicate `contains(key)` can be used all the way down to C++11 and allows R to build the package under default settings.